### PR TITLE
Check for dependencies and peerDependencies before calling Object.keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var camelCase = require('camelcase');
 // Extract package.json metadata
 function readPackageJSON () {
 	var pkg = JSON.parse(require('fs').readFileSync('./package.json'));
-	var dependencies = Object.keys(pkg.dependencies);
-	var peerDependencies = Object.keys(pkg.peerDependencies);
+	var dependencies = pkg.dependencies ? Object.keys(pkg.dependencies) : [];
+	var peerDependencies = pkg.peerDependencies ? Object.keys(pkg.peerDependencies) : [];
 
 	return {
 		name: pkg.name,


### PR DESCRIPTION
Got this error when trying to run the examples on your input-autosize component:

```
var dependencies = Object.keys(pkg.dependencies);
	                          ^
TypeError: Object.keys called on non-object
```

This PR simply check for the existence of deps and peerDeps. Maybe we should also check for its type? Or just try/catch? :dancer: 

Cheers!