### PR TITLE
adding config option for port alongside process.env.PORT

### DIFF
--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -6,7 +6,7 @@ module.exports = function (gulp, config) {
 		connect.server({
 			root: config.example.dist,
 			fallback: path.join(config.example.dist, 'index.html'),
-			port: process.env.PORT || 8000,
+			port: config.example.port || process.env.PORT || 8000,
 			livereload: true
 		});
 	});


### PR DESCRIPTION
So people can use the gulpfile config that this project is designed around, process env or default to 8000.