### PR TITLE
Adding brfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-core": "^5.8.25",
     "babel-plugin-object-assign": "^1.2.1",
     "babelify": "^6.3.0",
+    "brfs": "^1.4.1",
     "browserify": "^11.1.0",
     "browserify-shim": "^3.8.10",
     "camelcase": "^1.2.1",

--- a/tasks/examples.js
+++ b/tasks/examples.js
@@ -75,6 +75,7 @@ module.exports = function (gulp, config) {
 				fileBundle.transform(babelify.configure({
 					plugins: [require('babel-plugin-object-assign')]
 				}));
+				fileBundle.transform('brfs');
 				config.aliasify && fileBundle.transform(aliasify);
 				return {
 					file: file,


### PR DESCRIPTION
First off, thank you so much for your work and maintaining such awesome projects.

We have been using your react component boilerplate and have loved it so far. We ran into a use case where importing text files is desirable. In our case we have one file with example code. We import it directly via `require` to run it as an example, and load it via `fs` to show the source code.

Other libraries such as [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap/blob/master/docs/src/Samples.js) use [brfs](https://github.com/substack/brfs) to gain access to the `fs` library on the client. This PR adds `brfs` to only the examples build.


**Would we want to add a config flag to optionally run this command?**
The only reason I could see adding a config flag for this would be to speed up docs getting built.

**Is this addition useful to the community at large?**
I think the use case is general enough that everyone could benefit from this addition. Having the ability to require in arbitrary files and run them thru a markdown parser (or whatever you want) adds a great degree of flexibility in what we can accomplish. 

If we do move forward with this PR, it would probably be a good idea to have a reference to the added functionality in the README in this repo and the base component repo. I would be more than willing to do so if this is accepted. 