### PR TITLE
fix: `publish:npm` command throw an error in windows.

### DIFF
--- a/tasks/release.js
+++ b/tasks/release.js
@@ -19,7 +19,7 @@ module.exports = function (gulp, config) {
 
 	gulp.task('publish:npm', function (done) {
 		require('child_process')
-			.spawn('npm', ['publish'], { stdio: 'inherit' })
+			.spawn(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['publish'], { stdio: 'inherit' })
 			.on('close', done);
 	});
 


### PR DESCRIPTION
Hi Jed :) , in windows, use `npm` will throw an error,  consider using `npm.cmd`, it works fine.