### PR TITLE
upgrade gulp-git

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+####    WhiteSource Integration configuration file    ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-bump": "^0.3.1",
     "gulp-connect": "^2.2.0",
     "gulp-gh-pages": "^0.5.2",
-    "gulp-git": "^1.4.0",
+    "gulp-git": "^2.4.1",
     "gulp-less": "^3.0.3",
     "gulp-minify-css": "^1.2.1",
     "gulp-rename": "^1.2.2",

--- a/tasks/dist.js
+++ b/tasks/dist.js
@@ -49,7 +49,7 @@ module.exports = function (gulp, config) {
 				.pipe(gulp.dest('dist'))
 				.pipe(rename(config.component.pkgName + '.min.css'))
 				.pipe(minifyCSS())
-				.pipe(gulp.dest('dist'))
+				.pipe(gulp.dest('dist'));
 		});
 		buildTasks.push('build:dist:css');
 	}

--- a/tasks/examples.js
+++ b/tasks/examples.js
@@ -152,7 +152,7 @@ module.exports = function (gulp, config) {
 
 		var watchLESS = [];
 		if (config.example.less && config.example.less.length > 0) {
-			config.example.less.forEach(function(fileName) {
+			config.example.less.forEach(function (fileName) {
 				watchLESS.push(config.example.src + '/' + fileName);
 			});
 		}

--- a/tasks/lib.js
+++ b/tasks/lib.js
@@ -8,7 +8,7 @@ module.exports = function (gulp, config) {
 
 	gulp.task('build:lib', function () {
 		return gulp.src([ config.component.src + '/**/*.js', '!**/__tests__/**/*' ])
-			.pipe(babel({ plugins: [require('babel-plugin-object-assign')] }))
+			.pipe(babel({plugins: [require('babel-plugin-object-assign')]}))
 			.pipe(gulp.dest(config.component.lib));
 	});
 


### PR DESCRIPTION
`gulp-git` has `require-dir@0.1.0` as a dependency, and `require-dir@0.1.0` will fail with node v8.
So I upgraded gulp-git and fixed some code with `happiness --fix`.