### PR TITLE
Support for Node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-bump": "^0.3.1",
     "gulp-connect": "^2.2.0",
     "gulp-gh-pages": "^0.5.2",
-    "gulp-git": "^1.4.0",
+    "gulp-git": "2.5.1",
     "gulp-less": "^3.0.3",
     "gulp-minify-css": "^1.2.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
Upgraded require-dir version to latest to 2.5.1 to support Node 8.

Bug : https://stackoverflow.com/a/45545503/3702300